### PR TITLE
Feature skip empty value

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ This action helps solve this problem by allowing the user to provide the path an
 
 **Optional** The AWS KMS Key ARN to use to encrypt the key. Default uses the AWS Provided KMS Key ID .
 
+### `skip-empty-value`
+
+**Optional** When true - Skips creating/updating an SSM Parameter if provided value is empty. Default set to false.
+
+
 ## Example usage
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,9 @@ inputs:
   ssm-kms-key-id:
     description: "The AWS KMS Key ARN to use to encrypt the key"
     default: ""
+  skip-empty-value:
+    description: "Skips creating/updating an SSM Parameter if provided value is empty"
+    default: ""
 runs:
   using: "node16"
   main: "index.js"

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ async function run() {
       Description: core.getInput("ssm-value-description"),
     };
     core.info(`skip [${skip}] params.Value [${params.Value}]`);
-    if (skip === true && params.Value === '') {
+    if (skip === 'true' && params.Value === '') {
       core.info(`Skipping empty value parameter in path [${ssm_path}]`);
       return;
     }

--- a/index.js
+++ b/index.js
@@ -11,16 +11,16 @@ async function run() {
       apiVersion: "2014-11-06",
       region: core.getInput("aws-region"),
     });
+    var skip = core.getInput("skip-empty-value", { required: false });
     var params = {
       Name: core.getInput("ssm-path", { required: true }),
-      Value: core.getInput("ssm-value", { required: true }),
+      Value: core.getInput("ssm-value", { required: !skip }),
       Type: core.getInput("ssm-value-type", { required: true }),
       Overwrite: core.getBooleanInput("ssm-value-overwrite", {
         required: true,
       }),
       Description: core.getInput("ssm-value-description"),
     };
-    var skip = core.getInput("skip-empty-value", { required: false });
     if (skip === true && params.Value === '') {
       core.info(`Skipping empty value parameter in path [${ssm_path}]`);
       return;

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ async function run() {
       }),
       Description: core.getInput("ssm-value-description"),
     };
+    core.info(`params.Value [${params.Value}]`);
     if (skip === true && params.Value === '') {
       core.info(`Skipping empty value parameter in path [${ssm_path}]`);
       return;

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ async function run() {
       Description: core.getInput("ssm-value-description"),
     };
     core.info(`params.Value [${params.Value}]`);
-    if (skip === true && params.Value === '') {
+    if (skip === true && params.Value === undefined) {
       core.info(`Skipping empty value parameter in path [${ssm_path}]`);
       return;
     }

--- a/index.js
+++ b/index.js
@@ -20,6 +20,11 @@ async function run() {
       }),
       Description: core.getInput("ssm-value-description"),
     };
+    var skip = core.getInput("skip-empty-value", { required: false });
+    if (skip === true && params.Value === '') {
+      core.info(`Skipping empty value parameter in path [${ssm_path}]`);
+      return;
+    }
     core.debug(
       `Prepared parameters for SSM parameter update. ${JSON.stringify(params)}`
     );

--- a/index.js
+++ b/index.js
@@ -21,7 +21,6 @@ async function run() {
       }),
       Description: core.getInput("ssm-value-description"),
     };
-    core.info(`skip [${skip}] params.Value [${params.Value}]`);
     if (skip === 'true' && params.Value === '') {
       core.info(`Skipping empty value parameter in path [${ssm_path}]`);
       return;

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ async function run() {
       }),
       Description: core.getInput("ssm-value-description"),
     };
-    core.info(`params.Value [${params.Value}]`);
+    core.info(`params.Value [${params.Value}] ${params.Value===undefined}, ${params.Value===''} `);
     if (skip === true && params.Value === undefined) {
       core.info(`Skipping empty value parameter in path [${ssm_path}]`);
       return;

--- a/index.js
+++ b/index.js
@@ -21,8 +21,8 @@ async function run() {
       }),
       Description: core.getInput("ssm-value-description"),
     };
-    core.info(`params.Value [${params.Value}] ${params.Value===undefined}, ${params.Value===''} `);
-    if (skip === true && params.Value === undefined) {
+    core.info(`skip [${skip}] params.Value [${params.Value}]`);
+    if (skip === true && params.Value === '') {
       core.info(`Skipping empty value parameter in path [${ssm_path}]`);
       return;
     }


### PR DESCRIPTION
Added an additional **Optional** Field `skip-empty-value` which if provided with true will allow to ignore values that are empty and skip them without actually invoking the putParameter action.

The idea behind this feature is to allow the usage of calculated values and interpolated values that may be empty of missing like Github Environmental Values or Secrets.
