### PR TITLE
Update from Node 16 to Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,5 +27,5 @@ inputs:
     description: "The AWS KMS Key ARN to use to encrypt the key"
     default: ""
 runs:
-  using: "node16"
+  using: "node20"
   main: "index.js"


### PR DESCRIPTION
Node 16 has been deprecated by GitHub and causes deprecation warnings in workflows